### PR TITLE
由于 modbusTCP 具备连发和连收的解析功能，如果主机将所有的请求都寄存下来，未免过分占用资源，所以创建轻量级分支，仅对 modbu…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,31 @@
             "name": "gcc build_test",
             "type": "cppdbg",
             "request": "launch",
+            "program": "${workspaceRoot}\\Example\\win_test\\${fileBasenameNoExtension}.exe",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceRoot}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\111_APPS\\MSYS2\\mingw64\\bin\\gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "为 gdb 启用整齐打印",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "将反汇编风格设置为 Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "cmake build_test",
+            "type": "cppdbg",
+            "request": "launch",
             "program": "${workspaceRoot}\\build\\${fileBasenameNoExtension}.exe",
             "args": [],
             "stopAtEntry": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,29 +29,6 @@
             ],
             "group": "build",
             "detail": "测试项目编译。"
-        },
-        {
-            "type": "cppbuild",
-            "label": "C/C++: gcc.exe 生成活动文件",
-            "command": "C:\\111_APPS\\MSYS2\\mingw64\\bin\\gcc.exe",
-            "args": [
-                "-fdiagnostics-color=always",
-                "-g",
-                "${file}",
-                "-o",
-                "${fileDirname}\\${fileBasenameNoExtension}.exe"
-            ],
-            "options": {
-                "cwd": "${fileDirname}"
-            },
-            "problemMatcher": [
-                "$gcc"
-            ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "detail": "调试器生成的任务。"
         }
     ],
     "version": "2.0.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,27 +71,27 @@ target_link_options(${BUILD_PROJECT_NAME} PRIVATE
     -Wl,--gc-sections
 )
 
-set(BUILD_PROJECT_NAME TCP_Smain) # 控制编译TCP从机测试
-add_executable(${BUILD_PROJECT_NAME})
+# set(BUILD_PROJECT_NAME TCP_Smain) # 控制编译TCP从机测试
+# add_executable(${BUILD_PROJECT_NAME})
 
-target_compile_definitions(${BUILD_PROJECT_NAME} PRIVATE 
-    MBX_INCLUDE_USER_DEFINE_FILE # 控制使用用户自定义的配置文件
-)
-target_include_directories(${BUILD_PROJECT_NAME} PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/Example/win_test
-)
-target_sources(${BUILD_PROJECT_NAME} PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/Example/win_test/TCP_Smain.c
-)
-target_link_libraries(${BUILD_PROJECT_NAME} # 没有修饰词默认为 PRIVATE 
-    modbusx 
-    wsock32 ws2_32
-)
-# 添加链接器选项以生成 map 文件
-target_link_options(${BUILD_PROJECT_NAME} PRIVATE
-    -Wl,-Map=${BUILD_PROJECT_NAME}.map
-    -Wl,--gc-sections
-)
+# target_compile_definitions(${BUILD_PROJECT_NAME} PRIVATE 
+#     MBX_INCLUDE_USER_DEFINE_FILE # 控制使用用户自定义的配置文件
+# )
+# target_include_directories(${BUILD_PROJECT_NAME} PRIVATE
+#     ${CMAKE_CURRENT_LIST_DIR}/Example/win_test
+# )
+# target_sources(${BUILD_PROJECT_NAME} PRIVATE
+#     ${CMAKE_CURRENT_LIST_DIR}/Example/win_test/TCP_Smain.c
+# )
+# target_link_libraries(${BUILD_PROJECT_NAME} # 没有修饰词默认为 PRIVATE 
+#     modbusx 
+#     wsock32 ws2_32
+# )
+# # 添加链接器选项以生成 map 文件
+# target_link_options(${BUILD_PROJECT_NAME} PRIVATE
+#     -Wl,-Map=${BUILD_PROJECT_NAME}.map
+#     -Wl,--gc-sections
+# )
 
 
 # 启用测试

--- a/Example/win-gcc.cmake
+++ b/Example/win-gcc.cmake
@@ -6,7 +6,7 @@ set(CMAKE_CXX_COMPILER_FORCED TRUE)     # 强制指定C++编译器
 set(CMAKE_C_COMPILER_ID GNU)            # 设置C编译器ID为GNU
 set(CMAKE_CXX_COMPILER_ID GNU)          # 设置C++编译器ID为GNU
 
-set(TOOLCHAIN_PREFIX                 )
+set(TOOLCHAIN_PREFIX                 x86_64-w64-mingw32-)
 
 set(CMAKE_C_COMPILER                ${TOOLCHAIN_PREFIX}gcc)     # 设置C编译器
 set(CMAKE_ASM_COMPILER              ${CMAKE_C_COMPILER})        # 设置汇编编译器，使用C编译器

--- a/Example/win_test/TCP_Mmain.c
+++ b/Example/win_test/TCP_Mmain.c
@@ -1,0 +1,487 @@
+
+/**
+ * @file    RTU_Mmain.c
+ * windows使用虚拟串口与modbus测试软件进行通信
+ * 测试主机功能
+ * 其中大部分代码来自百度, 且懒得格式化
+ */
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdio.h>
+#include <string.h>
+
+#include <windows.h>
+
+#include <MBx_api.h>
+
+/* Private types -------------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+#if 1 //开启DEBUG打印
+#define LOGD(...) printf(__VA_ARGS__)
+#else //关闭DEBUG打印
+#define LOGD(...)
+#endif
+
+#if 1 //开启ERROR打印
+#define LOGE(...) printf(__VA_ARGS__)
+#else //关闭ERROR打印
+#define LOGE(...)
+#endif
+
+/* 测试使用的串口号定义 */
+#define COM_PORT_NAME "COM2"
+/* 测试使用的串口缓冲区大小 */
+#define BUF_SIZE 2048
+
+/* Private variables ---------------------------------------------------------*/
+
+/* 串口句柄 */
+HANDLE comHandle = INVALID_HANDLE_VALUE;
+
+/* modbusx Master对象 */
+_MBX_MASTER MBxMaster;
+_MBX_MASTER MBxMaster2;
+
+/* modbusx 从机成员对象 */
+_MBX_MASTER_TEAM_MEMBER MBxMasterMember1;
+_MBX_MASTER_TEAM_MEMBER MBxMasterMember2;
+
+/* 供映射的内存区域 */
+uint8_t  u8MapMem[64];
+uint16_t u16MapMem[64];
+uint32_t u36MapMem[64];
+uint64_t u64MapMem[64];
+float    fMapMem[64]; // 32位数据模型
+double   dMapMem[64]; // 64位数据模型
+
+/* Private Constants ---------------------------------------------------------*/
+static const _MBX_MAP_LIST_ENTRY MapList[];
+/* Private function prototypes -----------------------------------------------*/
+
+/* 示例的写失败时处理 */
+static uint32_t u8WriteTest1(void *value);
+static uint32_t u8WriteTest2(void *value);
+static uint32_t u16WriteTest1(void *value);
+static uint32_t u16WriteTest2(void *value);
+static uint32_t u32WriteTest1(void *value);
+static uint32_t fWriteTest1(void *value);
+
+/* 示例对指令错误的处理 */
+static void TestErrorConsume(void);
+
+/* 测试数据弄一些值的操作 */
+static void TestMemUpdate(uint32_t Cycle);
+
+/* 用于绑定的port函数 */
+uint32_t SerialSendPort(const void *Data, size_t Len);
+uint32_t SerialGetcPort(uint8_t *Data);
+
+/* 包装的win32串口驱动 */
+static HANDLE  SerialOpen(const char *com, int baud, int byteSize, int parity, int stopBits);
+static WINBOOL SerialClose(HANDLE hObject);
+
+/* 分立测试系列 */
+void MyRTUMasterTest(void);
+
+/* Private functions ---------------------------------------------------------*/
+
+int main(int argc, char *argv[])
+{
+    MBX_UNUSED_PARAM(argc)
+    MBX_UNUSED_PARAM(argv)
+    /* 打开串口 */
+    const char *com = COM_PORT_NAME;
+    comHandle       = SerialOpen(com, CBR_9600, 8, NOPARITY, ONESTOPBIT);
+    if(INVALID_HANDLE_VALUE == comHandle)
+    {
+        LOGE("OpenSerial %s fail!\r\n", COM_PORT_NAME);
+        return -1;
+    }
+    LOGD("Open %s Successfully!\r\n", COM_PORT_NAME);
+
+    /* RTU主机测试 */
+    MyRTUMasterTest( );
+
+    //关闭串口
+    SerialClose(comHandle);
+
+    return 0;
+}
+
+/**
+ * @brief RTU主机测试
+ * @param  无
+ */
+void MyRTUMasterTest(void)
+{
+    /* 申请主机对象发送及接收buffer */
+    uint8_t *SRxBuffer = (uint8_t *)malloc(84 * sizeof(uint8_t));
+    uint8_t *STxBuffer = (uint8_t *)malloc(84 * sizeof(uint8_t));
+
+    /* 初始化modbus主机1 */
+    if(MBx_Master_TCP_Init(&MBxMaster,     // 主机对象
+                           SerialSendPort, // 发送函数
+                           SerialGetcPort, // 接收函数
+                           SRxBuffer,      // 库内接收buffer分配
+                           84,             // 接收buffer最大长度
+                           STxBuffer,      // 库内发送buffer分配
+                           84)             // 发送buffer最大长度
+       != MBX_API_RETURN_DEFAULT)
+    {
+        /* 初始化错误 自行判断返回值差错 */
+    }
+
+    /* 添加主机1管理的从机1 */
+    if(MBx_Master_Member_Add(&MBxMaster,        // 主机对象
+                             &MBxMasterMember1, // 从机成员对象
+                             1,                 // 从机ID
+                             MapList)           // 该从机对象的映射表
+       != MBX_API_RETURN_DEFAULT)
+    {
+        /* 表明映射表或ID等传参异常 */
+    }
+
+    /* 添加主机1管理的从机2(如果真的有，把传参填写正常) */
+    if(MBx_Master_Member_Add(&MBxMaster,        // 主机对象
+                             &MBxMasterMember2, // 从机成员对象
+                             MBX_PARA_NULL,     // 从机ID
+                             MBX_PARA_NULL)     // 该从机对象的映射表
+       != MBX_API_RETURN_DEFAULT)
+    {
+        /* 表明映射表或ID等传参异常 */
+    }
+
+    /* 假装初始化主机2(如果真的有，把传参填写正常) */
+    MBx_Master_TCP_Init(&MBxMaster2,    // 主机对象
+                        MBX_PARA_NULL,  // 发送函数
+                        MBX_PARA_NULL,  // 接收函数
+                        MBX_PARA_NULL,  // 库内接收buffer分配
+                        MBX_PARA_NULL,  // 接收buffer最大长度
+                        MBX_PARA_NULL,  // 库内发送buffer分配
+                        MBX_PARA_NULL); // 发送buffer最大长度
+
+    while(1)
+    {
+        MBx_Ticks(15000);    // 换算为微秒传入MBx驱动 链表自动驱动
+        TestMemUpdate(15);   // 毫秒传入测试函数
+        TestErrorConsume( ); // 处理对从指令产生的错误
+        Sleep(1);            // 实际延迟大约是15ms
+    }
+}
+/******************测试数据弄一些值的操作******************/
+/**
+ * @brief 测试值周期变化
+ * @param  Cycle 周期 ms
+ */
+static void TestMemUpdate(uint32_t Cycle)
+{
+    static uint16_t u16buffer[10]; // 测试数组
+    static uint16_t u16test   = 0;
+    static uint32_t u32test   = 0;
+    static float    ftest     = 0.0;
+    static uint32_t ftest_cpy = 0;
+    static uint32_t i;
+    i += Cycle;
+    if((i % 500) == 0) // 分频到500ms
+    {
+        MBx_Master_Read_Reg_Request(&MBxMaster, 1, 0, 4);           // 请求读取1号从机的0地址的4个寄存器
+        MBx_Master_Read_Input_Reg_Request(&MBxMaster, 1, 0x100, 2); // 请求读取1号从机的0x100地址的2个寄存器 (作为输入寄存器只读)
+        MBx_Master_Read_Reg_Request(&MBxMaster, 1, 0x200, 2);       // 请求读取1号从机的0x200地址的2个寄存器 拼凑为32位数据
+        MBx_Master_Read_Reg_Request(&MBxMaster, 1, 0x300, 2);       // 请求读取1号从机的0x300地址的2个寄存器 拼凑为32位浮点
+    }
+    if(i >= 2000) // 分频到两秒
+    {
+        u16test++;
+        u32test++;
+        ftest += 1.1;
+        u16buffer[0] = u16test;
+        u16buffer[1] = u16test + 1;
+        u16buffer[2] = u16test + 2;
+        u16buffer[3] = u16test + 3;
+        MBx_Master_Write_Reg_Mul_Request(&MBxMaster, 1, 0, 4, (uint8_t *)&u16buffer[0], 8); // 请求写入1号从机的0地址的4个寄存器，写成功时自动同步进映射内存区
+        u16buffer[0] = u16test;
+        u16buffer[1] = u16test;
+        MBx_Master_Write_Reg_Mul_Request(&MBxMaster, 1, 0x100, 2, (uint8_t *)&u16buffer[0], 4); // 请求写入1号从机的0x100地址的2个寄存器 由于定义为输入寄存器，应当会产生失败写入
+        u16buffer[0] = (u32test >> 16) & 0xFFFF;
+        u16buffer[1] = u32test & 0xFFFF;
+        MBx_Master_Write_Reg_Mul_Request(&MBxMaster, 1, 0x200, 2, (uint8_t *)&u16buffer[0], 4); // 请求写入1号从机的0x200地址的2个寄存器 无符号32位拼凑
+        /* 取真实内存值的原版写法，但会带来警告 */
+        // u16buffer[0] = (*(uint32_t *)(&ftest) >> 16) & 0xFFFF;
+        // u16buffer[1] = (*(uint32_t *)(&ftest)) & 0xFFFF;
+        /* 增加开销的写法，但能消除警告 */
+        memcpy(&ftest_cpy, &ftest, sizeof(float));
+        u16buffer[0] = (ftest_cpy >> 16) & 0xFFFF;
+        u16buffer[1] = ftest_cpy & 0xFFFF;
+        MBx_Master_Write_Reg_Mul_Request(&MBxMaster, 1, 0x300, 2, (uint8_t *)&u16buffer[0], 4); // 请求写入1号从机的0x300地址的2个寄存器 浮点拼凑
+        i = 0;
+    }
+}
+
+/******************应当自行编写的对请求错误的处理******************/
+/**
+ * @brief 示例对指令请求错误的处理
+ * @param  无
+ */
+static void TestErrorConsume(void)
+{
+    uint8_t  FuncCode;
+    uint8_t  ErrorCode;
+    uint16_t AddrStart;
+    uint16_t RegNum;
+    while(MBx_Master_Error_Get(&MBxMaster, &FuncCode, &ErrorCode, &AddrStart, &RegNum) == MBX_API_RETURN_DEFAULT)
+    {
+        switch(FuncCode)
+        {
+        case MBX_FUNC_READ_COIL:
+            printf("在读取线圈时发生错误, 错误码为0x%02X, 起始地址为0x%04X, 寄存器数量为0x%04X\n", ErrorCode, AddrStart, RegNum);
+            break;
+        case MBX_FUNC_READ_DISC_INPUT:
+            printf("在读取离散输入时发生错误, 错误码为0x%02X, 起始地址为0x%04X, 寄存器数量为0x%04X\n", ErrorCode, AddrStart, RegNum);
+            break;
+        case MBX_FUNC_READ_REG:
+            printf("在读取保持寄存器时发生错误, 错误码为0x%02X, 起始地址为0x%04X, 寄存器数量为0x%04X\n", ErrorCode, AddrStart, RegNum);
+            break;
+        case MBX_FUNC_READ_INPUT_REG:
+            printf("在读取输入寄存器时发生错误, 错误码为0x%02X, 起始地址为0x%04X, 寄存器数量为0x%04X\n", ErrorCode, AddrStart, RegNum);
+            break;
+        case MBX_FUNC_WRITE_COIL:
+            printf("在写入单个线圈时时发生错误, 错误码为0x%02X, 地址为0x%04X\n", ErrorCode, AddrStart);
+            break;
+        case MBX_FUNC_WRITE_REG:
+            printf("在写入单个保持寄存器时时发生错误, 错误码为0x%02X, 地址为0x%04X\n", ErrorCode, AddrStart);
+            break;
+        case MBX_FUNC_WRITE_COIL_MUL:
+            printf("在写入多个线圈时发生错误, 错误码为0x%02X, 起始地址为0x%04X, 寄存器数量为0x%04X\n", ErrorCode, AddrStart, RegNum);
+            break;
+        case MBX_FUNC_WRITE_REG_MUL:
+            printf("在写入多个保持寄存器时发生错误, 错误码为0x%02X, 起始地址为0x%04X, 寄存器数量为0x%04X\n", ErrorCode, AddrStart, RegNum);
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+/******************寄存器地址映射表示例******************/
+
+/* 为了实现更快速的查找，库内采用二分法查询地址表
+    地址表必须手动以升序排列，由于C11标准不支持动态宏，暂时无法在编译阶段自动检查 */
+static const _MBX_MAP_LIST_ENTRY MapList[] = {
+    /*  寄存器地址        映射到的内部内存              内部内存数据属性            写时异常立即回调(NULL为忽略写异常)  */
+    {.Addr = 0x0000, .Memory = &u8MapMem[10],  .Type = MBX_REG_TYPE_U8,    .Handle = u8WriteTest1 },
+    {.Addr = 0x0001, .Memory = &u8MapMem[11],  .Type = MBX_REG_TYPE_U8,    .Handle = u8WriteTest2 },
+    {.Addr = 0x0002, .Memory = &u8MapMem[12],  .Type = MBX_REG_TYPE_U8,    .Handle = NULL         },
+    {.Addr = 0x0003, .Memory = &u8MapMem[13],  .Type = MBX_REG_TYPE_U8,    .Handle = NULL         },
+    {.Addr = 0x0100, .Memory = &u16MapMem[10], .Type = MBX_REG_TYPE_U16,   .Handle = u16WriteTest1},
+    {.Addr = 0x0101, .Memory = &u16MapMem[11], .Type = MBX_REG_TYPE_U16,   .Handle = u16WriteTest2},
+    {.Addr = 0x0200, .Memory = &u36MapMem[10], .Type = MBX_REG_TYPE_U32_H, .Handle = u32WriteTest1}, /* 多寄存器组合映射同一个内存变量，写入异常回调应该是同一个(硬性要求) 模拟大端内存(ABCD排列 基于传输协议，这是最合适的) */
+    {.Addr = 0x0201, .Memory = &u36MapMem[10], .Type = MBX_REG_TYPE_U32_L, .Handle = u32WriteTest1},
+    {.Addr = 0x0300, .Memory = &fMapMem[10],   .Type = MBX_REG_TYPE_U32_H, .Handle = fWriteTest1  }, /* 浮点映射测试 模拟大端内存(ABCD排列 基于传输协议，这是最合适的)*/
+    {.Addr = 0x0301, .Memory = &fMapMem[10],   .Type = MBX_REG_TYPE_U32_L, .Handle = fWriteTest1  },
+
+    MBX_MAP_LIST_END
+};
+
+/******************供绑定的写失败时处理函数示例******************/
+/**
+ * @brief uint8_t 映射的写失败时处理
+ * @param value 库内传参，对于uint8_t的映射将传入(uint8_t *)类型
+ * @return 标准返回，请依照 MBx_api.h 的 “API返回集” 部分编写
+*/
+static uint32_t u8WriteTest1(void *value)
+{
+    uint8_t ValueGet = (*(uint8_t *)value);
+    /* 期望写入ValueGet而没有成功写入 */
+    printf("向0x000写入 %d 失败\n", ValueGet);
+    return MBX_API_RETURN_DEFAULT;
+}
+
+/**
+ * @brief uint8_t 映射的写失败时处理
+ * @param value 库内传参，对于uint8_t的映射将传入(uint8_t *)类型
+ * @return 标准返回，请依照 MBx_api.h 的 “API返回集” 部分编写
+*/
+static uint32_t u8WriteTest2(void *value)
+{
+    uint8_t ValueGet = (*(uint8_t *)value);
+    /* 期望写入ValueGet而没有成功写入 */
+    printf("向0x001写入 %d 失败\n", ValueGet);
+    return MBX_API_RETURN_DEFAULT;
+}
+
+/**
+ * @brief uint16_t 映射的写失败时处理
+ * @param value 库内传参，对于uint16_t的映射将传入(uint16_t *)类型
+ * @return 标准返回，请依照 MBx_api.h 的 “API返回集” 部分编写
+*/
+static uint32_t u16WriteTest1(void *value)
+{
+    uint16_t ValueGet = (*(uint16_t *)value);
+    /* 期望写入ValueGet而没有成功写入 */
+    printf("向0x100写入 %d 失败\n", ValueGet);
+    return MBX_API_RETURN_DEFAULT;
+}
+
+/**
+ * @brief uint16_t 映射的写失败时处理
+ * @param value 库内传参，对于 uint16_t 的映射将传入(uint16_t *)类型
+ * @return 标准返回，请依照 MBx_api.h 的 “API返回集” 部分编写
+*/
+static uint32_t u16WriteTest2(void *value)
+{
+    uint16_t ValueGet = (*(uint16_t *)value);
+    /* 期望写入ValueGet而没有成功写入 */
+    printf("向0x101写入 %d 失败\n", ValueGet);
+    return MBX_API_RETURN_DEFAULT;
+}
+
+/**
+ * @brief uint32_t 映射的写失败时处理
+ * @param value 库内传参，对于 uint32_t 的映射将传入(uint32_t *)类型
+ * @return 标准返回，请依照 MBx_api.h 的 “API返回集” 部分编写
+*/
+static uint32_t u32WriteTest1(void *value)
+{
+    MBX_UNUSED_PARAM(value)
+    // (*(uint32_t *)value);
+    /* 期望写入ValueGet而没有成功写入 */
+    return MBX_API_RETURN_DEFAULT;
+}
+
+/**
+ * @brief float 映射的写失败时处理
+ * @param value 库内传参，对于 uint32_t 的映射将传入(uint32_t *)类型
+ * @return 标准返回，请依照 MBx_api.h 的 “API返回集” 部分编写
+*/
+static uint32_t fWriteTest1(void *value)
+{
+    MBX_UNUSED_PARAM(value)
+    // (*(float *)value);
+    /* 期望写入ValueGet而没有成功写入 */
+    return MBX_API_RETURN_DEFAULT;
+}
+
+/******************利用windows串口驱动编写的mbx port函数******************/
+/**
+ * @brief 将 MBX_SEND_MODE_BYTES 宏置1后, 可用多字节发送port
+ * @param Data 发送buffer指针
+ * @param Len 期望发送的长度
+ * @return port标准返回
+ */
+uint32_t SerialSendPort(const void *Data, size_t Len)
+{
+    WINBOOL b     = FALSE; // 发送操作标识
+    DWORD   wWLen = 0;     // 实际发送数据长度
+    /* 尝试发送 */
+    b = WriteFile(comHandle, Data, Len, &wWLen, NULL);
+    if(b && wWLen == Len)
+        return MBX_PORT_RETURN_DEFAULT;
+    else
+        return MBX_PORT_RETURNT_ERR_INDEFINITE;
+}
+
+/**
+ * @brief 数据接收port, 实现功能为取单字节, 返回值表示是否取接收成功
+ * @param Data 字节指针, 取到的字节
+ * @return port标准返回
+ */
+uint32_t SerialGetcPort(uint8_t *Data)
+{
+    WINBOOL b     = FALSE; // 接收操作标识
+    DWORD   wRLen = 0;     // 实际接收数据长度
+    /* 尝试接收 */
+    b = ReadFile(comHandle, Data, 1, &wRLen, NULL);
+    if(b == TRUE && wRLen == 1)
+    {
+        return MBX_PORT_RETURN_DEFAULT;
+    }
+    else
+    {
+        return MBX_PORT_RETURNT_ERR_INDEFINITE;
+    }
+}
+
+/******************以下为串口驱动, 应当分离为port文件, 示例就算了******************/
+/**
+ * @brief 打开串口
+ * @param com 串口名称, 如COM1, COM2
+ * @param baud 波特率：常用取值：CBR_9600、CBR_19200、CBR_38400、CBR_115200、CBR_230400、CBR_460800
+ * @param byteSize 数位大小：可取值7、8；
+ * @param parity 校验方式：可取值NOPARITY、ODDPARITY、EVENPARITY、MARKPARITY、SPACEPARITY
+ * @param stopBits 停止位：ONESTOPBIT、ONE5STOPBITS、TWOSTOPBITS；
+ * @return 返回生成的串口对象
+ */
+HANDLE SerialOpen(const char *com, int baud, int byteSize, int parity, int stopBits)
+{
+    DCB          dcb;
+    BOOL         b = FALSE;
+    COMMTIMEOUTS CommTimeouts;
+    HANDLE       comHandle = INVALID_HANDLE_VALUE;
+
+    //打开串口
+    comHandle = CreateFile(com,                          //串口名称
+                           GENERIC_READ | GENERIC_WRITE, //可读、可写
+                           0,                            // No Sharing
+                           NULL,                         // No Security
+                           OPEN_EXISTING,                // Open existing port only
+                           FILE_ATTRIBUTE_NORMAL,        // Non Overlapped I/O
+                           NULL);                        // Null for Comm Devices
+
+    if(INVALID_HANDLE_VALUE == comHandle)
+    {
+        LOGE("CreateFile fail\r\n");
+        return comHandle;
+    }
+
+    // 设置读写缓存大小
+    b = SetupComm(comHandle, BUF_SIZE, BUF_SIZE);
+    if(!b)
+    {
+        LOGE("SetupComm fail\r\n");
+    }
+
+    //设定读写超时
+    CommTimeouts.ReadIntervalTimeout         = MAXDWORD;                                  //读间隔超时
+    CommTimeouts.ReadTotalTimeoutMultiplier  = 0;                                         //读时间系数
+    CommTimeouts.ReadTotalTimeoutConstant    = 0;                                         //读时间常量
+    CommTimeouts.WriteTotalTimeoutMultiplier = 1;                                         //写时间系数
+    CommTimeouts.WriteTotalTimeoutConstant   = 1;                                         //写时间常量
+    b                                        = SetCommTimeouts(comHandle, &CommTimeouts); //设置超时
+    if(!b)
+    {
+        LOGE("SetCommTimeouts fail\r\n");
+    }
+
+    //设置串口状态属性
+    GetCommState(comHandle, &dcb);                //获取当前
+    dcb.BaudRate = baud;                          //波特率
+    dcb.ByteSize = byteSize;                      //每个字节有位数
+    dcb.Parity   = parity;                        //无奇偶校验位
+    dcb.StopBits = stopBits;                      //一个停止位
+    b            = SetCommState(comHandle, &dcb); //设置
+    if(!b)
+    {
+        LOGE("SetCommState fail\r\n");
+    }
+
+    return comHandle;
+}
+
+/**
+ * @brief 关闭串口
+ * @param hObject
+ * @return
+ */
+WINBOOL SerialClose(HANDLE hObject)
+{
+    WINBOOL b = FALSE;
+    /* 尝试关闭串口 */
+    b = CloseHandle(hObject);
+    if(!b)
+    {
+        LOGE("CloseHandle fail\r\n");
+    }
+
+    LOGD("Program Exit.\r\n");
+    return b;
+}

--- a/Example/win_test/测试介绍.md
+++ b/Example/win_test/测试介绍.md
@@ -10,23 +10,25 @@ modbus调试软件则需要使用虚拟串口的另一端。
 
 # 测试流
 
-使用了vscode的c/c++插件，和gcc编译链，以及gdb调试。
+使用了vscode的c/c++插件。
+
+和gcc编译链，以及gdb调试，这些自行在电脑上安装。
 
 tasks.json中"gcc build_test"任务的gcc路径应该改为自己的。
 
 launch.json中"C/C++: gcc.exe 生成和调试活动文件"的gdb路径应该改为自己的。
 
-使用ctrl+shift+P，run build task，运行名为"gcc build_test"的编译任务。
+打开期望编译的入口c文件，比如RTU_Smain.c。使用ctrl+shift+P，run build task，运行名为"gcc build_test"的编译任务。
 
-在调试透视窗启用调试(此时应该打开期望调试的入口c文件)。
+打开期望调试的入口c文件，比如RTU_Smain.c。在调试透视窗，在下拉框选择"gcc build_test"的调试任务，启用调试。
 
-# RTU从机测试
+# 从机测试
 
 轮询时间均为1ms。
 
 ![](../README.DATA/作为从机展示poll上位机.png)
 
-而且支持自动分帧(虽然是不符合modbus标准的，纯私货)。依照标准如果不符合一发一回出现连帧，那么啥也不干。
+而且支持自动分帧哪怕RTU(虽然是不符合modbus标准的，纯私货)。依照标准如果不符合一发一回出现连帧，那么啥也不干。
 
 ![](../README.DATA/作为从机展示连帧处理.png)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Static Badge](https://img.shields.io/badge/license%20-%20MIT%20-%20blue)
 [![C/C++ CI](https://github.com/stbanana/modbusX/actions/workflows/c-cpp.yml/badge.svg)](https://github.com/stbanana/modbusX/actions/workflows/c-cpp.yml)
 
-一个正在开发中的 modbus 协议解析栈。
+一个物理驱动层解耦的 modbus 协议解析栈。
 
 我对协议库的理解是：只需要另外实现数据的流入和流出 port，并最多另外定时调用一个时基函数，就可以驱动起整个库(轮询)。
 
@@ -30,6 +30,7 @@
 - [ ] TCP 主从机的输入和保持寄存器读写
 - [ ] RTU 主从机的线圈和离散输入读写
 - [ ] TCP 主从机的线圈和离散输入读写
+- [ ] 动态地址映射表的支持
 
 
 

--- a/common/include/MBx_api.h
+++ b/common/include/MBx_api.h
@@ -325,7 +325,7 @@ extern uint32_t MBx_Slave_RTU_Init(_MBX_SLAVE *MBxSlave, uint8_t SlaveID, const 
 extern uint32_t MBx_Slave_TCP_Init(_MBX_SLAVE *MBxSlave, uint8_t SlaveID, const _MBX_MAP_LIST_ENTRY *MAP, MBX_SEND_PTR MBxSend, MBX_GTEC_PTR MBxGetc, uint8_t *RxBuffer, uint32_t RxBufferSize, uint8_t *TxBuffer, uint32_t TxBufferSize);
 /*主机API*/
 extern uint32_t MBx_Master_RTU_Init(_MBX_MASTER *MBxMaster, MBX_SEND_PTR MBxSend, MBX_GTEC_PTR MBxGetc, uint32_t BaudRate, uint8_t *RxBuffer, uint32_t RxBufferSize, uint8_t *TxBuffer, uint32_t TxBufferSize);
-extern uint32_t MBx_Master_TCP_Init(_MBX_MASTER *MBxMaster, MBX_SEND_PTR MBxSend, MBX_GTEC_PTR MBxGetc, uint32_t BaudRate, uint8_t *RxBuffer, uint32_t RxBufferSize, uint8_t *TxBuffer, uint32_t TxBufferSize);
+extern uint32_t MBx_Master_TCP_Init(_MBX_MASTER *MBxMaster, MBX_SEND_PTR MBxSend, MBX_GTEC_PTR MBxGetc, uint8_t *RxBuffer, uint32_t RxBufferSize, uint8_t *TxBuffer, uint32_t TxBufferSize);
 extern uint32_t MBx_Master_Member_Add(_MBX_MASTER *MBxMaster, _MBX_MASTER_TEAM_MEMBER *MBxMember, uint8_t SlaveID, const _MBX_MAP_LIST_ENTRY *MAP);
 extern uint32_t MBx_Master_Error_Get(_MBX_MASTER *pMaster, uint8_t *Func, uint8_t *Error, uint16_t *AddrStart, uint16_t *RegNum);
 extern uint32_t MBx_Master_Read_Coil_Request(_MBX_MASTER *pMaster, uint8_t SlaveID, uint16_t StartAddr, uint16_t ReadNum);
@@ -336,6 +336,7 @@ extern uint32_t MBx_Master_Write_Coil_Request(_MBX_MASTER *pMaster, uint8_t Slav
 extern uint32_t MBx_Master_Write_Reg_Request(_MBX_MASTER *pMaster, uint8_t SlaveID, uint16_t Addr, uint16_t Value);
 extern uint32_t MBx_Master_Write_Coil_Mul_Request(_MBX_MASTER *pMaster, uint8_t SlaveID, uint16_t StartAddr, uint16_t WriteNum, uint8_t *Data, uint16_t DataLen);
 extern uint32_t MBx_Master_Write_Reg_Mul_Request(_MBX_MASTER *pMaster, uint8_t SlaveID, uint16_t StartAddr, uint16_t WriteNum, uint8_t *Data, uint16_t DataLen);
+/*地址映射表API*/
 
 /* 便于拓展应用的开发, 用户无需调用 */
 extern void     MBx_Init_Runtime(_MBX_COMMON_RUNTIME *MBxRuntime);

--- a/common/include/MBx_utility.h
+++ b/common/include/MBx_utility.h
@@ -117,15 +117,15 @@ extern "C"
  * @param pMBX  MBX对象指针
  * @param rLen 期望删除的 字节长度
  */
-#define MBxRxBufferRemove(pMBX, rLen)                                                                        \
-    do                                                                                                       \
-    {                                                                                                        \
-        pSlave->RxExist.Len -= rLen;                                                                         \
-        if(pSlave->RxExist.Len > 0)                                                                          \
-        {                                                                                                    \
-            MBx_utility_MemMove(pSlave->RxExist.Buffer, pSlave->RxExist.Buffer + rLen, pSlave->RxExist.Len); \
-        }                                                                                                    \
-    }                                                                                                        \
+#define MBxRxBufferRemove(pMBX, rLen)                                                                  \
+    do                                                                                                 \
+    {                                                                                                  \
+        pMBX->RxExist.Len -= rLen;                                                                     \
+        if(pMBX->RxExist.Len > 0)                                                                      \
+        {                                                                                              \
+            MBx_utility_MemMove(pMBX->RxExist.Buffer, pMBX->RxExist.Buffer + rLen, pMBX->RxExist.Len); \
+        }                                                                                              \
+    }                                                                                                  \
     while(0)
 
 /**

--- a/common/source/MBx_Master_Handle.c
+++ b/common/source/MBx_Master_Handle.c
@@ -5,14 +5,14 @@
  **** All rights reserved                                       ****
 
  ********************************************************************************
- * File Name     : MBx_Master_RTU_Handle.c
+ * File Name     : MBx_Master_Handle.c
  * Author        : yono
  * Date          : 2024-08-02
  * Version       : 1.0
 ********************************************************************************/
 /**************************************************************************/
 /*
-    modbus RTU主机消息系统的底层消息处理, 内部函数, 不应由用户调用
+    modbus 主机消息系统的底层消息处理, 内部函数, 不应由用户调用
      此时应当已经提取了完整指令
      系列函数使用标准返回
 */
@@ -27,11 +27,11 @@
 /* Private function prototypes -----------------------------------------------*/
 /* Private functions ---------------------------------------------------------*/
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 读取一组线圈
+ * @brief modbus 主机消息系统的底层消息处理 读取一组线圈
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_READ_COIL_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_READ_COIL_Handle(_MBX_MASTER *pMaster)
 {
     _MBX_MASTER_TEAM_MEMBER *pMember;
     uint16_t                 i = 0;
@@ -69,11 +69,11 @@ uint32_t MBx_Master_RTU_READ_COIL_Handle(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 读取一组离散输入寄存器
+ * @brief modbus 主机消息系统的底层消息处理 读取一组离散输入寄存器
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_READ_DISC_INPUTL_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_READ_DISC_INPUTL_Handle(_MBX_MASTER *pMaster)
 {
     _MBX_MASTER_TEAM_MEMBER *pMember;
     uint16_t                 i = 0;
@@ -111,11 +111,11 @@ uint32_t MBx_Master_RTU_READ_DISC_INPUTL_Handle(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 读取一个或多个保持寄存器
+ * @brief modbus 主机消息系统的底层消息处理 读取一个或多个保持寄存器
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_READ_REG_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_READ_REG_Handle(_MBX_MASTER *pMaster)
 {
     _MBX_MASTER_TEAM_MEMBER *pMember;
     uint16_t                 i = 0;
@@ -137,11 +137,11 @@ uint32_t MBx_Master_RTU_READ_REG_Handle(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 读取一个或多个输入寄存器
+ * @brief modbus 主机消息系统的底层消息处理 读取一个或多个输入寄存器
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_READ_INPUT_REG_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_READ_INPUT_REG_Handle(_MBX_MASTER *pMaster)
 {
     _MBX_MASTER_TEAM_MEMBER *pMember;
     uint16_t                 i = 0;
@@ -163,11 +163,11 @@ uint32_t MBx_Master_RTU_READ_INPUT_REG_Handle(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 写单个线圈
+ * @brief modbus 主机消息系统的底层消息处理 写单个线圈
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_WRITE_COIL_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_WRITE_COIL_Handle(_MBX_MASTER *pMaster)
 {
     // 写入成功，同步映射数据
     _MBX_MASTER_TEAM_MEMBER *pMember;
@@ -193,11 +193,11 @@ uint32_t MBx_Master_RTU_WRITE_COIL_Handle(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 写单个保持寄存器
+ * @brief modbus 主机消息系统的底层消息处理 写单个保持寄存器
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_WRITE_REG_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_WRITE_REG_Handle(_MBX_MASTER *pMaster)
 {
     // 写入成功，同步映射数据
     _MBX_MASTER_TEAM_MEMBER *pMember;
@@ -215,11 +215,11 @@ uint32_t MBx_Master_RTU_WRITE_REG_Handle(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 写多个线圈
+ * @brief modbus 主机消息系统的底层消息处理 写多个线圈
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_WRITE_COIL_MUL_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_WRITE_COIL_MUL_Handle(_MBX_MASTER *pMaster)
 {
     // 写入成功，同步映射数据
     _MBX_MASTER_TEAM_MEMBER *pMember;
@@ -258,11 +258,11 @@ uint32_t MBx_Master_RTU_WRITE_COIL_MUL_Handle(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 写入多个保持寄存器
+ * @brief modbus 主机消息系统的底层消息处理 写入多个保持寄存器
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_WRITE_REG_MUL_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_WRITE_REG_MUL_Handle(_MBX_MASTER *pMaster)
 {
     // 写入成功，同步映射数据
     _MBX_MASTER_TEAM_MEMBER *pMember;
@@ -286,11 +286,11 @@ uint32_t MBx_Master_RTU_WRITE_REG_MUL_Handle(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief modbus RTU主机消息系统的底层消息处理 对于错误代码的处理
+ * @brief modbus 主机消息系统的底层消息处理 对于错误代码的处理
  * @param pMaster MBX主机对象指针
  * @return 标准返回
  */
-uint32_t MBx_Master_RTU_Error_Handle(_MBX_MASTER *pMaster)
+uint32_t MBx_Master_Error_Handle(_MBX_MASTER *pMaster)
 {
     _MBX_MASTER_TEAM_MEMBER *pMember;
     uint16_t                 i = 0; // 临时参数

--- a/common/source/MBx_Master_Init.c
+++ b/common/source/MBx_Master_Init.c
@@ -72,8 +72,6 @@ uint32_t MBx_Master_RTU_Init(_MBX_MASTER *MBxMaster, //
     MBx_Init_Master_Request(&MBxMaster->Request);
     /* 将当前操作的从机号清除 */
     MBxMaster->Config.SlaveID = 0;
-    /* 将从机链表头清除 */
-    MBxMaster->SlaveChainRoot = NULL;
 
     /*  传参有关部分    */
     /* 绑定回调函数部分 */
@@ -97,7 +95,6 @@ uint32_t MBx_Master_RTU_Init(_MBX_MASTER *MBxMaster, //
  * @param MBxMaster 期望初始化的MBX主机对象指针
  * @param MBxSend 绑定的主机发送port函数
  * @param MBxGetc 绑定的主机接收port函数
- * @param BaudRate 典型波特率
  * @param RxBuffer 绑定的接收buffer区域
  * @param RxBufferSize 绑定的接收buffer最大长度
  * @param TxBuffer 绑定的发送buffer区域
@@ -107,7 +104,6 @@ uint32_t MBx_Master_RTU_Init(_MBX_MASTER *MBxMaster, //
 uint32_t MBx_Master_TCP_Init(_MBX_MASTER *MBxMaster, //
                              MBX_SEND_PTR MBxSend,
                              MBX_GTEC_PTR MBxGetc,
-                             uint32_t     BaudRate,
                              uint8_t     *RxBuffer,
                              uint32_t     RxBufferSize,
                              uint8_t     *TxBuffer,
@@ -136,8 +132,7 @@ uint32_t MBx_Master_TCP_Init(_MBX_MASTER *MBxMaster, //
     MBx_Init_Master_Request(&MBxMaster->Request);
     /* 将当前操作的从机号清除 */
     MBxMaster->Config.SlaveID = 0;
-    /* 将从机链表头清除 */
-    MBxMaster->SlaveChainRoot = NULL;
+    /* 将当前累计的事务号清除 */
 
     /*  传参有关部分    */
     /* 绑定回调函数部分 */
@@ -149,7 +144,7 @@ uint32_t MBx_Master_TCP_Init(_MBX_MASTER *MBxMaster, //
     MBxMaster->TxExist.Buffer = TxBuffer;
     MBxMaster->TxExist.LenMAX = TxBufferSize;
     /* 初始化属性 */
-    MBx_Init_Attr(&MBxMaster->Attr, MBX_MODEL_TCP, MBX_MODE_MASTER, BaudRate, MBX_PARA_NULL);
+    MBx_Init_Attr(&MBxMaster->Attr, MBX_MODEL_TCP, MBX_MODE_MASTER, MBX_PARA_NULL, MBX_PARA_NULL);
     if(State != MBX_API_RETURN_DEFAULT)
         MBx_MODULE_TRACE_ADD_ERR(MBxMaster, State);
 

--- a/common/source/MBx_Master_Parse.c
+++ b/common/source/MBx_Master_Parse.c
@@ -24,6 +24,7 @@
 /* Private macros ------------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 extern void MBx_Master_RTU_Parse(_MBX_MASTER *pMaster);
+extern void MBx_Master_TCP_Parse(_MBX_MASTER *pMaster);
 /* Private functions ---------------------------------------------------------*/
 
 /**
@@ -38,7 +39,7 @@ void MBx_Master_Parse(_MBX_MASTER *pMaster)
         MBx_Master_RTU_Parse(pMaster);
         break;
     case MBX_MODEL_TCP:
-        // MBx_Master_Parse_TCP( );
+        MBx_Master_TCP_Parse(pMaster);
         break;
     default:
         break;

--- a/common/source/MBx_Master_TCP_Parse.c
+++ b/common/source/MBx_Master_TCP_Parse.c
@@ -5,14 +5,14 @@
  **** All rights reserved                                       ****
 
  ********************************************************************************
- * File Name     : MBx_Master_RTU_Parse.c
+ * File Name     : MBx_Master_TCP_Parse.c
  * Author        : yono
  * Date          : 2024-07-25
  * Version       : 1.0
 ********************************************************************************/
 /**************************************************************************/
 /*
-    modbus单主机消息解析系统的RTU分支, 内部函数, 不应由用户调用
+    modbus单主机消息解析系统的TCP分支, 内部函数, 不应由用户调用
 */
 
 /* Includes ------------------------------------------------------------------*/
@@ -34,41 +34,33 @@ extern uint32_t    MBx_Master_WRITE_COIL_MUL_Handle(_MBX_MASTER *pMaster);
 extern uint32_t    MBx_Master_WRITE_REG_MUL_Handle(_MBX_MASTER *pMaster);
 extern uint32_t    MBx_Master_Error_Handle(_MBX_MASTER *pMaster);
 
-static inline void MBx_Master_Parse_RTU_Func_Get(_MBX_MASTER *pMaster);
-static inline void MBx_Master_Parse_RTU_AddrStar_Get(_MBX_MASTER *pMaster);
+static inline void MBx_Master_Parse_TCP_Func_Get(_MBX_MASTER *pMaster);
+static inline void MBx_Master_Parse_TCP_AddrStar_Get(_MBX_MASTER *pMaster);
 /* Private functions ---------------------------------------------------------*/
 /**
- * @brief modbusX从机消息解析系统 RTU分支
+ * @brief modbusX从机消息解析系统 TCP分支
  * @param pMaster MBX从机对象指针
  */
-void MBx_Master_RTU_Parse(_MBX_MASTER *pMaster)
+void MBx_Master_TCP_Parse(_MBX_MASTER *pMaster)
 {
     uint32_t FrameLen  = 0;                  // 当前帧的完整帧长度。规范应在函数最前定义。
     uint32_t ErrorCode = MBX_EXCEPTION_NONE; // 错误码
 
-    /* 提取功能码 */
-    MBx_Master_Parse_RTU_Func_Get(pMaster);
-    /* 提取寄存器起始地址 */
-    MBx_Master_Parse_RTU_AddrStar_Get(pMaster);
-    /* 依据功能码不同. 检测帧完整性 */
-    switch(pMaster->Parse.Func)
+    /* 审查是否符合最小帧长 */
+    if(pMaster->RxExist.Len < 9)
     {
-    case MBX_FUNC_READ_COIL:
-    case MBX_FUNC_READ_DISC_INPUT:
-    case MBX_FUNC_READ_REG:
-    case MBX_FUNC_READ_INPUT_REG:
-        FrameLen = 5 + pMaster->RxExist.Buffer[2];
-        break;
-    case MBX_FUNC_WRITE_COIL:
-    case MBX_FUNC_WRITE_REG:
-    case MBX_FUNC_WRITE_COIL_MUL:
-    case MBX_FUNC_WRITE_REG_MUL:
-        FrameLen = 8;
-        break;
-    default: // 可能是异常帧回复
-        FrameLen = 5;
-        break;
+        MBxRxBufferEmpty(pMaster);
+        return; // 帧不完整, 弃帧
     }
+
+    /* 解析TCP特有报文头，推移帧成为RTU帧 */
+    FrameLen = ((uint16_t)pMaster->RxExist.Buffer[4] << 8) + pMaster->RxExist.Buffer[5];
+    MBxRxBufferRemove(pMaster, 6);
+
+    /* 提取功能码 */
+    MBx_Master_Parse_TCP_Func_Get(pMaster);
+    /* 提取寄存器起始地址 */
+    MBx_Master_Parse_TCP_AddrStar_Get(pMaster);
 
     /* 审查从机ID号是否符合请求 */
     if(pMaster->Parse.SlaveID != pMaster->RxExist.Buffer[0])
@@ -82,13 +74,6 @@ void MBx_Master_RTU_Parse(_MBX_MASTER *pMaster)
     {
         MBxRxBufferEmpty(pMaster);
         return; // 帧不完整, 弃帧
-    }
-
-    /* 检测CRC (一个丑陋的写法，但能稍微节省性能)*/
-    if((((uint16_t)(pMaster->RxExist.Buffer[FrameLen - 1]) << 8) | (pMaster->RxExist.Buffer[FrameLen - 2])) != // 提取CRC值
-       MBx_utility_crc16(pMaster->RxExist.Buffer, FrameLen - 2))                                               // 计算CRC值
-    {
-        ErrorCode = MBX_EXCEPTION_CRC;
     }
 
     /* 进入不同的分支处理 */
@@ -136,19 +121,19 @@ void MBx_Master_RTU_Parse(_MBX_MASTER *pMaster)
 }
 
 /**
- * @brief 提取 RTU消息功能码
+ * @brief 提取 TCP消息功能码
  * @param pMaster MBX从机对象指针
  */
-static inline void MBx_Master_Parse_RTU_Func_Get(_MBX_MASTER *pMaster)
+static inline void MBx_Master_Parse_TCP_Func_Get(_MBX_MASTER *pMaster)
 {
     pMaster->Parse.Func = pMaster->RxExist.Buffer[1];
 }
 
 /**
- * @brief 提取 RTU寄存器起始地址
+ * @brief 提取 TCP寄存器起始地址
  * @param pMaster MBX从机对象指针
  */
-static inline void MBx_Master_Parse_RTU_AddrStar_Get(_MBX_MASTER *pMaster)
+static inline void MBx_Master_Parse_TCP_AddrStar_Get(_MBX_MASTER *pMaster)
 {
     pMaster->Parse.AddrStart = (((uint16_t)pMaster->RxExist.Buffer[2] << 8) //地址高八位
                                 | pMaster->RxExist.Buffer[3]);              // 地址低八位

--- a/common/source/MBx_Slave_TCP_Parse.c
+++ b/common/source/MBx_Slave_TCP_Parse.c
@@ -32,7 +32,7 @@ extern uint32_t    MBx_Slave_WRITE_COIL_Handle(_MBX_SLAVE *pSlave);
 extern uint32_t    MBx_Slave_WRITE_REG_Handle(_MBX_SLAVE *pSlave);
 extern uint32_t    MBx_Slave_WRITE_COIL_MUL_Handle(_MBX_SLAVE *pSlave);
 extern uint32_t    MBx_Slave_WRITE_REG_MUL_Handle(_MBX_SLAVE *pSlave);
-extern void        MBx_Slave_Error_Handle(_MBX_SLAVE *pSlave, uint8_t ErrorCode);
+extern void        MBx_Slave_Error_TCP_Handle(_MBX_SLAVE *pSlave, uint8_t ErrorCode);
 
 static inline void MBx_Slave_Parse_TCP_Func_Get(_MBX_SLAVE *pSlave);
 static inline void MBx_Slave_Parse_TCP_AddrStar_Get(_MBX_SLAVE *pSlave);
@@ -143,7 +143,7 @@ void MBx_Slave_TCP_Parse(_MBX_SLAVE *pSlave)
 
     if(ErrorCode != MBX_EXCEPTION_NONE)
     {
-        MBx_Slave_Error_Handle(pSlave, ErrorCode); // 剔除旧消息，产生错误回复消息
+        MBx_Slave_Error_TCP_Handle(pSlave, ErrorCode); // 剔除旧消息，产生错误回复消息
     }
 
     /* 删除已处理消息 */


### PR DESCRIPTION
…sTCP 的写错误进行重查询处理，以在保留基础功能时不额外占用过多资源